### PR TITLE
Prune selected counts earlier from the "frontend backend" query processing

### DIFF
--- a/dep/vessel/github.json
+++ b/dep/vessel/github.json
@@ -1,7 +1,7 @@
 {
   "owner": "obsidiansystems",
   "repo": "vessel",
-  "branch": "develop",
-  "rev": "b425ddf3eb892bb2a62611ecb6e2f9df03de9b9a",
-  "sha256": "08sqzcbbrvdcr59pq1ga12lvgf1621fdiazvg4lcvz0bq9a267q1"
+  "branch": "difference",
+  "rev": "211d6504a1049a70511067641e31efcd3495a6ac",
+  "sha256": "1gg3sgh1df0mayn0xx2d4zxpxs8m368lg4xn0awwqjfvrqhc4myv"
 }

--- a/frontend/src/Frontend/Query.hs
+++ b/frontend/src/Frontend/Query.hs
@@ -31,6 +31,7 @@ deriveArgDictV ''V
 type FrontendV = Vessel V
 
 type FrontendQuery = FrontendV (Const SelectedCount)
+type FrontendQuery' = FrontendV Proxy
 type FrontendQueryResult = FrontendV Identity
 
 queryLogin


### PR DESCRIPTION
The query handling code shouldn't deal with selected counters; they
should be filtered (>= 0) and then thrown away since they need to be
recropped anyways. We then use a basic:

  subtractV (\ Proxy Proxy -> Nothing) newQuery oldQuery

the most basic subtraction to make a patch to query.